### PR TITLE
tmrank

### DIFF
--- a/src/main/java/org/oscii/api/LexiconProtocol.java
+++ b/src/main/java/org/oscii/api/LexiconProtocol.java
@@ -6,7 +6,12 @@ import org.apache.logging.log4j.Logger;
 import org.oscii.concordance.AlignedCorpus;
 import org.oscii.concordance.AlignedSentence;
 import org.oscii.concordance.SentenceExample;
-import org.oscii.lex.*;
+import org.oscii.lex.Definition;
+import org.oscii.lex.Expression;
+import org.oscii.lex.Lexicon;
+import org.oscii.lex.Meaning;
+import org.oscii.lex.Ranker;
+import org.oscii.lex.Translation;
 import org.oscii.neural.Word2VecManager;
 import org.oscii.neural.Word2VecManager.MalformedQueryException;
 import org.oscii.neural.Word2VecManager.UnsupportedLanguageException;
@@ -94,7 +99,7 @@ public class LexiconProtocol {
         logger.debug("TIMING examples: {}", (endTime - startTime) / 1e9);
         if (bHasEmbeddings) {
             startTime = endTime;
-            boolean bSuccess = embeddings.rankConcordances(request.source, request.context, results);
+            boolean bSuccess = embeddings.rankConcordances(request.source, request.context, results, request.memory);
             endTime = System.nanoTime();
             logger.debug("TIMING embeddings: {} ({})", (endTime - startTime) / 1e9, results.size());
             if (!bSuccess) {

--- a/src/main/java/org/oscii/neural/Word2VecManager.java
+++ b/src/main/java/org/oscii/neural/Word2VecManager.java
@@ -138,6 +138,9 @@ public class Word2VecManager {
         double sim = VectorMath.cosineSimilarity(tokensMean, contextMean);
         if (Double.isNaN(sim)) {
           sim = -2.0; // Give it a low score.
+        } else if (ex.memoryId > 0) {
+          // personal TM match: add +1.0 so entries appear on top (note: similarity is not cosine sim any more)
+          sim += 1.0;
         }
         ex.similarity = sim;
       } catch(Exception e) {

--- a/src/main/java/org/oscii/neural/Word2VecManager.java
+++ b/src/main/java/org/oscii/neural/Word2VecManager.java
@@ -118,7 +118,7 @@ public class Word2VecManager {
    * @param context
    * @param concordances
    */
-  public boolean rankConcordances(String lang, String context, List<SentenceExample> concordances) {
+  public boolean rankConcordances(String lang, String context, List<SentenceExample> concordances, int memoryId) {
     if (!supports(lang) || context.length() == 0 || concordances.size() == 0) {
       return false;
     }
@@ -138,8 +138,11 @@ public class Word2VecManager {
         double sim = VectorMath.cosineSimilarity(tokensMean, contextMean);
         if (Double.isNaN(sim)) {
           sim = -2.0; // Give it a low score.
+        } else if (ex.memoryId == memoryId) {
+          // personal TM match in same project: place on top by adding +2.0 (note: similarity is not cosine sim any more)
+          sim += 2.0;
         } else if (ex.memoryId > 0) {
-          // personal TM match: add +1.0 so entries appear on top (note: similarity is not cosine sim any more)
+          // personal TM match: add +1.0 so entries appear on top but below same-project matches (also note: see above)
           sim += 1.0;
         }
         ex.similarity = sim;


### PR DESCRIPTION
places personal memory matches on top of concordance examples list by boosting the similarity score

might need to further tweak this, e.g. cap number of entries for each category (personal memory match in same project, personal memory match in other projects, background match)
